### PR TITLE
Update parse function to properly test if value is NaN

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,11 +21,12 @@ module.exports = function(value) {
   if (value === false || value === 'false') {
     return false;
   }
-  // the checks for true booleans above are because
-  // Chrome 34 (and perhaps other versions) return the following
-  // isNaN as false even if the value being checked it true or false.
-  // e.g. isNaN(true) and isNaN(false) both return false
-  if (value !== '' && !isNaN(value)) {
+  //  according to the IEEE floating-point standard (https://en.wikipedia.org/wiki/IEEE_floating_point) NaN should be treated as
+  //  unqeual to iteself. Javascript follows this standard. NaN is the only value in javascript that is unqeual to iteself.
+  //  using isNan is unsafe because it coerces its argument to a Number before testing the value.
+  //  so test that value does not equal value will only return false if value
+  //  is NaN
+  if (value !== '' && value !== value) {
     return value * 1;
   }
   if (value.indexOf && (value.indexOf('{') === 0 || value.indexOf('[') === 0)) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,7 +21,7 @@ module.exports = function(value) {
   if (value === false || value === 'false') {
     return false;
   }
-  //  according to the IEEE floating-point standard NaN should be treated as unqeual to iteself. Javascript follows this standard. 
+  //  according to the IEEE floating-point standard NaN should be treated as unqeual to iteself. Javascript follows this standard.
   //  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN#Testing_against_NaN
   //  NaN is the only value in javascript that is unqeual to iteself.
   //  using isNan is unsafe because it coerces its argument to a Number before testing the value.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,11 +21,12 @@ module.exports = function(value) {
   if (value === false || value === 'false') {
     return false;
   }
-  //  according to the IEEE floating-point standard (https://en.wikipedia.org/wiki/IEEE_floating_point) NaN should be treated as
-  //  unqeual to iteself. Javascript follows this standard. NaN is the only value in javascript that is unqeual to iteself.
+  //  according to the IEEE floating-point standard NaN should be treated as unqeual to iteself. Javascript follows this standard. 
+  //  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN#Testing_against_NaN
+  //  NaN is the only value in javascript that is unqeual to iteself.
   //  using isNan is unsafe because it coerces its argument to a Number before testing the value.
-  //  so test that value does not equal value will only return false if value
-  //  is NaN
+  //  so testing that value does not equal iteself only returns false if value is NaN
+  //  @TODO:  es6 update to Number.isNan (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN)
   if (value !== '' && value !== value) {
     return value * 1;
   }


### PR DESCRIPTION
Javascript follows the IEEE floating-point standard that `NaN` be treated as unequal to itself. The problem with using `isNaN()` is that Javascript coerces the argument into a Number, which can lead to unpredictable results. The [current idiom](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN#Testing_against_NaN) is to have the Javascript value check equality against itself. This reliably determines if the value is `NaN` because `NaN` is only unequal to itself. (ES6 introduces `Number.isNan()`, which properly checks if a value is `NaN`)