### PR TITLE
Add Webpack information to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,31 @@ Vault.Session.list();
 Vault.Local.list();
 Vault.Cookie.list();
 ```
+
+### Webpack
+
+To use Vault.js with webpack you'll need to use json-loader.
+
+```
+npm i --save json-loader
+```
+
+Then in webpack config:
+
+```
+  module: {
+    loaders: [
+      {test: /\.json$/, loader: "json-loader" }
+    ]
+  },
+```
+
+You may also want to set up an alias so your require statements are a bit cleaner:
+
+```
+  resolve: {
+    alias: {
+      'vault.js': 'vault.js/browser.js'
+    }
+  }
+```  


### PR DESCRIPTION
This PR adds some information about using Vault.js with webpack to the Readme.

![image](https://cloud.githubusercontent.com/assets/857664/15757695/b0dbeae4-28bb-11e6-94c7-47c3791ebf78.png)
